### PR TITLE
Limit this source only to the Lua filetype

### DIFF
--- a/lua/cmp_nvim_lua/init.lua
+++ b/lua/cmp_nvim_lua/init.lua
@@ -8,6 +8,10 @@ source.new = function()
   return self
 end
 
+source.is_available = function()
+  return vim.bo.filetype == 'lua'
+end
+
 source.get_keyword_pattern = function()
   return [[\w\+]]
 end


### PR DESCRIPTION
Otherwise irrelevant completions show up in non-Lua filetypes when typing `string.` or `vim.` or similar.